### PR TITLE
Add new manifest path to jsonValidation

### DIFF
--- a/packages/vscode-ui5-language-assistant/package.json
+++ b/packages/vscode-ui5-language-assistant/package.json
@@ -24,6 +24,7 @@
       {
         "fileMatch": [
           "webapp/manifest.json",
+          "src/manifest.json",
           "src/main/webapp/manifest.json"
         ],
         "url": "https://raw.githubusercontent.com/SAP/ui5-manifest/master/schema.json"


### PR DESCRIPTION
Add the path where the manifest.json is stored in TypeScript projects.